### PR TITLE
Add language name conversion helper

### DIFF
--- a/pdx translation tool/translator_app/utils/localization.py
+++ b/pdx translation tool/translator_app/utils/localization.py
@@ -590,3 +590,19 @@ def get_language_code(lang_name_en):
         'Turkish': "turkish"
     }
     return mapping.get(lang_name_en, "english")
+
+def get_language_name(lang_code):
+    """Converts Paradox-style language code back to its English language name."""
+    mapping = {
+        "english": 'English',
+        "korean": 'Korean',
+        "simp_chinese": 'Simplified Chinese',
+        "french": 'French',
+        "german": 'German',
+        "spanish": 'Spanish',
+        "japanese": 'Japanese',
+        "portuguese": 'Portuguese',
+        "russian": 'Russian',
+        "turkish": 'Turkish'
+    }
+    return mapping.get(lang_code.lower(), 'English')


### PR DESCRIPTION
## Summary
- add `get_language_name` helper to translate language codes back to names

## Testing
- `python -m py_compile run_translator.py translator_app/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684145ec5a3883228a559cb6ff4f5eda