### PR TITLE
Improve diff filtering logic

### DIFF
--- a/pdx translation tool/translator_app/gui/comparison_review_window.py
+++ b/pdx translation tool/translator_app/gui/comparison_review_window.py
@@ -707,10 +707,27 @@ class ComparisonReviewWindow(ctk.CTkToplevel):
         mode = self.display_mode_var.get()
         if mode == "diff":
             max_len = max(len(self.current_original_lines), len(self.current_translated_lines))
+            check_regex = self.check_regex_errors_var_crw.get()
+            check_source = self.check_source_remnants_var_crw.get()
+
             for i in range(max_len):
                 o = self.current_original_lines[i] if i < len(self.current_original_lines) else ""
                 t = self.current_translated_lines[i] if i < len(self.current_translated_lines) else ""
-                if o != t:
+
+                line_diff = o.strip() != t.strip()
+                regex_err = False
+                source_err = False
+
+                if check_regex or check_source:
+                    if i < len(self.current_translated_lines):
+                        if check_regex:
+                            regex_err = self.translator_engine._check_line_for_yml_errors_engine(t)
+                        if check_source:
+                            value = self.translator_engine._extract_yml_value(t)
+                            source_err = self.translator_engine._check_source_remnants_optimized(
+                                value, self.current_original_lines, i)
+
+                if line_diff or regex_err or source_err:
                     self.original_text_widget.insert(tk.END, o)
                     self.translated_text_widget.insert(tk.END, t)
         else:


### PR DESCRIPTION
## Summary
- update diff mode to ignore whitespace and include regex/source errors

## Testing
- `python -m py_compile 'pdx translation tool/translator_app/gui/comparison_review_window.py'`

------
https://chatgpt.com/codex/tasks/task_e_68415249d99c8322b67a9b048301d2c8