### PR TITLE
Fix regex validation & add refresh UI

### DIFF
--- a/pdx translation tool/translator_app/core/translator_engine.py
+++ b/pdx translation tool/translator_app/core/translator_engine.py
@@ -43,7 +43,8 @@ class TranslatorEngine:
         self.regex_valid_yml_value_str = r'^[^"]*"([^"\\]|\\.)*$'
 
         # 2. 부적절한 선행 따옴표 패턴
-        self.regex_error_improper_leading_quote_str = r'(?<![\r\n\t  ])"(?=[A-Za-z])'
+        # 첫 따옴표를 정상으로 인식하도록 문자열 시작 위치에서는 매치되지 않게 수정
+        self.regex_error_improper_leading_quote_str = r'(?<!^)(?<![\r\n\t ])"(?=[A-Za-z])'
 
         # 정규표현식 컴파일된 객체들 (성능 향상을 위해 미리 컴파일)
         self.compiled_regex_valid_yml_value = None

--- a/pdx translation tool/translator_app/gui/panels/control_panel.py
+++ b/pdx translation tool/translator_app/gui/panels/control_panel.py
@@ -27,6 +27,17 @@ class ControlPanel(ctk.CTkFrame):
         self.stop_btn_widget.pack(side="left", padx=(5,0))
         self.stop_btn_tooltip = Tooltip(self.stop_btn_widget, "") # 툴팁은 번역 중지용으로 유지
 
+        # --- UI 새로고침 버튼 ---
+        self.refresh_ui_button = ctk.CTkButton(
+            button_container_frame,
+            text="🔄",
+            width=32,
+            height=32,
+            command=self.main_app.refresh_ui
+        )
+        self.refresh_ui_button.pack(side="left", padx=(5,0))
+        self.refresh_button_tooltip = Tooltip(self.refresh_ui_button, "")
+
         # 진행 상황 프레임 (이전과 동일)
         self.progress_frame_display = ctk.CTkFrame(self, corner_radius=10)
         self.progress_frame_display.pack(fill="x", padx=0, pady=(10,0)) # 버튼과 간격 추가
@@ -60,3 +71,5 @@ class ControlPanel(ctk.CTkFrame):
             self.stop_btn_widget.configure(text=texts.get("stop_button"))
             self.stop_btn_tooltip.update_text(texts.get("stop_button_tooltip"))
             self.progress_frame_display_title_label.configure(text=texts.get("progress_frame"))
+            if hasattr(self, 'refresh_button_tooltip'):
+                self.refresh_button_tooltip.update_text(texts.get("refresh_button_tooltip", "Refresh"))


### PR DESCRIPTION
## Summary
- ensure regex check doesn't flag normal lines by mistake
- add refresh button in control panel for convenience

## Testing
- `python -m py_compile "pdx translation tool/translator_app/core/translator_engine.py" "pdx translation tool/translator_app/gui/panels/control_panel.py"`

------
https://chatgpt.com/codex/tasks/task_e_68416cb6c4608322a13eeab097facd9c